### PR TITLE
feat: localstorage for randomquestion

### DIFF
--- a/src/components/RandomQuestion/RandomQuestion.tsx
+++ b/src/components/RandomQuestion/RandomQuestion.tsx
@@ -25,29 +25,41 @@ export const RandomQuestion: FC<RandomQuestionProps> = ({
     if (!items || !shapes) {
       return;
     }
-    getNextQuestion();
+    const savedQuestion = localStorage.getItem('currentQuestion');
+    if (savedQuestion) {
+      setCurrentQuestion(savedQuestion);
+      setCurrentShapeIdx(parseInt(localStorage.getItem('currentShapeIdx') || '0'));
+    } else {
+      getNextQuestion();
+    }
   }, []);
 
   const CurrentShape = useMemo(() => shapes[currentShapeIdx], [currentShapeIdx, shapes]);
 
-  let previousPicks: (typeof items)[number][] = [];
-
   const getNextQuestion = () => {
+    let previousPicks: string[] = JSON.parse(localStorage.getItem('previousPicks') || '[]');
+
     const nextQuestion = getRandomUniqueItem(items, previousPicks);
-    setCurrentShapeIdx((prevIndex) => (prevIndex + 1) % shapes.length);
+    const nextShapeIdx = (currentShapeIdx + 1) % shapes.length;
 
     if (nextQuestion) {
       previousPicks.push(nextQuestion);
-
+      localStorage.setItem('previousPicks', JSON.stringify(previousPicks));
+      localStorage.setItem('currentQuestion', nextQuestion);
+      localStorage.setItem('currentShapeIdx', nextShapeIdx.toString());
       setCurrentQuestion(nextQuestion);
+      setCurrentShapeIdx(nextShapeIdx);
     } else {
       // All questions have been used, reset previousPicks
-      previousPicks = [];
-      const question = getRandomUniqueItem(items, previousPicks);
+      localStorage.setItem('previousPicks', '[]');
+      const question = getRandomUniqueItem(items, []);
       if (!question) {
         return;
       }
+      localStorage.setItem('currentQuestion', question);
+      localStorage.setItem('currentShapeIdx', '0');
       setCurrentQuestion(question);
+      setCurrentShapeIdx(0);
     }
   };
 


### PR DESCRIPTION
Switched to using localstorage for keeping track of the current and previous questions. 

A new question is now only generated when clicking the shape. You can get the same question twice but not in a row, only if you've circled through all questions

https://github.com/user-attachments/assets/c3170112-4cd0-4d00-8bb2-2ba3a8d9d75c

