### PR TITLE
feat: body fonts

### DIFF
--- a/src/app/[lang]/fonts.ts
+++ b/src/app/[lang]/fonts.ts
@@ -1,13 +1,13 @@
-import {JetBrains_Mono, Poppins} from 'next/font/google';
+import {JetBrains_Mono, Roboto} from 'next/font/google';
 
 export const jetbrains_mono = JetBrains_Mono({
   subsets: ['latin'],
   variable: '--font-jetbrains_mono',
 });
 
-export const poppins = Poppins({
+export const roboto = Roboto({
   subsets: ['latin'],
   display: 'swap',
-  variable: '--font-poppins',
+  variable: '--font-roboto',
   weight: '400',
 });

--- a/src/app/[lang]/fonts.ts
+++ b/src/app/[lang]/fonts.ts
@@ -1,0 +1,13 @@
+import {JetBrains_Mono, Poppins} from 'next/font/google';
+
+export const jetbrains_mono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains_mono',
+});
+
+export const poppins = Poppins({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-poppins',
+  weight: '400',
+});

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -4,8 +4,7 @@ import type {Metadata} from 'next';
 import {cn} from '@/lib/utils';
 import {PHProvider} from '@/lib/providers/PHProvider';
 import dynamic from 'next/dynamic';
-
-const jetbrains_mono = JetBrains_Mono({subsets: ['latin']});
+import {jetbrains_mono, poppins} from './fonts';
 
 export const metadata: Metadata = {
   manifest: '/manifest.json',
@@ -24,7 +23,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <PHProvider>
-        <body className={cn(jetbrains_mono.className, '')}>
+        <body className={cn(jetbrains_mono.variable, poppins.variable, '')}>
           <PostHogPageView />
           {children}
         </body>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -4,7 +4,7 @@ import type {Metadata} from 'next';
 import {cn} from '@/lib/utils';
 import {PHProvider} from '@/lib/providers/PHProvider';
 import dynamic from 'next/dynamic';
-import {jetbrains_mono, poppins} from './fonts';
+import {jetbrains_mono, roboto} from './fonts';
 
 export const metadata: Metadata = {
   manifest: '/manifest.json',
@@ -23,7 +23,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <PHProvider>
-        <body className={cn(jetbrains_mono.variable, poppins.variable, '')}>
+        <body className={cn(jetbrains_mono.variable, roboto.variable, '')}>
           <PostHogPageView />
           {children}
         </body>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,10 +66,10 @@
     @apply overscroll-none border-border;
   }
   body {
-    @apply font-jetbrains_mono overscroll-none bg-background text-foreground;
+    @apply overscroll-none bg-background font-jetbrains_mono text-foreground;
   }
   p {
-    @apply font-poppins;
+    @apply font-roboto;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,39 +59,6 @@
     --yellow: 50 98% 61%;
     --blue: 241 99% 66%;
   }
-  /* .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-
-    --white: 0 0% 100%;
-    --black: 0 0% 0%;
-    --green: 148 87% 36%;
-    --pink: 279 96% 81%;
-    --orange: 30 97% 52%;
-    --yellow: 47 97% 64%;
-  } */
 }
 
 @layer base {
@@ -99,7 +66,10 @@
     @apply overscroll-none border-border;
   }
   body {
-    @apply overscroll-none bg-background text-foreground;
+    @apply font-jetbrains_mono overscroll-none bg-background text-foreground;
+  }
+  p {
+    @apply font-poppins;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        poppins: 'var(--font-poppins)',
+        jetbrains_mono: 'var(--font-jetbrains_mono)',
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        poppins: 'var(--font-poppins)',
+        roboto: 'var(--font-roboto)',
         jetbrains_mono: 'var(--font-jetbrains_mono)',
       },
       backgroundImage: {


### PR DESCRIPTION
Jetbrains mono font for everything except p-tags. The fonts are accessible in Tailwind as variables font-roboto and font-jetbrains_mono

Before:
![before](https://github.com/user-attachments/assets/70234ad1-a4a5-4608-bfe2-f92829e0603a)


After:
![afer](https://github.com/user-attachments/assets/fccd20d8-545e-4734-8f99-7134b6b4d593)

Closes #41 