### PR TITLE
fix: ssc exercise colors

### DIFF
--- a/messages/sv.json
+++ b/messages/sv.json
@@ -149,7 +149,7 @@
         "title": "Kapitel 3: Fortsätt",
         "subtitle": "4-5 minuter | 2-20 deltagare",
         "description": "I detta kapitel kommer ni att brainstorma och diskutera vilka saker ni borde fortsätta göra som gemenskap för att bättre stödja produktivitet, kommunikation, etc. Ge ett exempel på hur detta kan hjälpa dig och gemenskapen att blomstra.",
-        "button": "Gå til Fortsätt",
+        "button": "Gå till Fortsätt",
         "steps": [
           {
             "title": "Fortsätt",

--- a/src/components/CarouselPagination.tsx
+++ b/src/components/CarouselPagination.tsx
@@ -1,6 +1,6 @@
-import {paginationColors} from '@/lib/mock';
-import {cn} from '@/lib/utils';
-import React, {FC, useCallback} from 'react';
+import { paginationColors } from '@/lib/constants';
+import { cn } from '@/lib/utils';
+import { FC, useCallback } from 'react';
 
 type CarouselPaginationProps = {
   steps: any[];

--- a/src/components/ssc-exercise/index.tsx
+++ b/src/components/ssc-exercise/index.tsx
@@ -1,24 +1,16 @@
 'use client';
-import {PageLayout, RiveAnimation, Timer} from '@/components';
+import {Header, PageLayout, RiveAnimation, Timer} from '@/components';
+import {CarouselPagination} from '@/components/CarouselPagination';
+import {Complete} from '@/components/icons';
 import {Button} from '@/components/ui/button';
+import {Carousel, CarouselApi, CarouselContent, CarouselItem} from '@/components/ui/carousel';
+import {paginationColors} from '@/lib/constants';
 import {sscMock} from '@/lib/mock';
 import {Step} from '@/lib/types';
-import React, {useMemo, useState, useEffect} from 'react';
-import {Header} from '@/components';
-import {CarouselPagination} from '@/components/CarouselPagination';
-import {
-  Carousel,
-  CarouselApi,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from '@/components/ui/carousel';
-import {Link} from '@/navigation';
-import {Complete} from '@/components/icons';
-import {useTranslations} from 'next-intl';
+import {Link, useRouter} from '@/navigation';
 import {ArrowRight} from 'lucide-react';
-import {useRouter} from '@/navigation';
+import {useTranslations} from 'next-intl';
+import React, {useEffect, useMemo, useState} from 'react';
 
 export type SSCExerciseProps = {
   chapter: string;
@@ -36,6 +28,23 @@ const SSCExercise: React.FC<SSCExerciseProps> = ({chapter, steps}) => {
     stop: sscMock.stop.steps,
     continue: sscMock.continue.steps,
   };
+
+  const getButtonVariant = useMemo(() => {
+    switch (paginationColors[currentStep + 1]) {
+      case 'bg-blue':
+        return 'blue';
+      case 'bg-pink':
+        return 'pink';
+      case 'bg-orange':
+        return 'orange';
+      case 'bg-red':
+        return 'red';
+      case 'bg-green':
+        return 'green';
+      default:
+        return 'pink';
+    }
+  }, [currentStep]);
 
   const chapterSteps = useMemo(() => {
     return chapterMap[chapter as keyof typeof chapterMap] || sscMock.start.steps;
@@ -80,7 +89,7 @@ const SSCExercise: React.FC<SSCExerciseProps> = ({chapter, steps}) => {
 
   return (
     <PageLayout
-      backgroundColor="bg-blue"
+      backgroundColor={sscMock[chapter as Exclude<keyof typeof sscMock, 'about'>].backgroundColor}
       header={
         <Header onBackButton={previousStep}>
           <CarouselPagination steps={steps} currentStep={currentStep} />
@@ -94,7 +103,7 @@ const SSCExercise: React.FC<SSCExerciseProps> = ({chapter, steps}) => {
             </Link>
           </Button>
         ) : (
-          <Button variant="yellow" onClick={nextStep}>
+          <Button variant={getButtonVariant} onClick={nextStep}>
             {t('nextStep')} <ArrowRight />
           </Button>
         )

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,3 +20,5 @@ export const ShapeColors: ColorObject = {
 export type ColorObject = {
   [key: string]: string;
 };
+
+export const paginationColors = ['bg-blue', 'bg-pink', 'bg-orange', 'bg-green', 'bg-red'];

--- a/src/lib/mock.tsx
+++ b/src/lib/mock.tsx
@@ -1,5 +1,5 @@
-import type {ButtonProps} from '@/components';
-import {AboutProps, StepContent} from './types';
+import type { ButtonProps } from '@/components';
+import { AboutProps, StepContent } from './types';
 
 export const ccMock = {
   about: {
@@ -134,4 +134,3 @@ export const mockPassItOn: PassItOnItem[] = [
   },
 ];
 
-export const paginationColors = ['bg-blue', 'bg-pink', 'bg-orange', 'bg-green', 'bg-red'];


### PR DESCRIPTION
### What has been changed?

_Please write a short description of what has been changed._

1. Correct background color for each ssc exercise
2. Next button should change color

### Checklist:

_Before you submit your pull request, please review the following checklist:_

- [x] All required rive animations have been implemented
- [x] All text content have been implemened in the correct language (added to the json or CMS)
- [x] Changes have been tested on desktop and mobile
- [x] The linter/ prettier have been run and corrected any misspellings

### Screenshots or recordings

_For bigger changes, please provide screenshots or recordings of what has been changed._

| Before           | After            |
| ---------------- | ---------------- |
| ![Screenshot 2024-10-11 at 13 05 10](https://github.com/user-attachments/assets/b9bf7278-67e0-4f00-a23a-4d72e4997f8b) | ![Screenshot 2024-10-11 at 13 03 49](https://github.com/user-attachments/assets/4d9ee35b-6642-40c1-95ff-cde80ea3f704)  |
| ![Screenshot 2024-10-11 at 13 05 25](https://github.com/user-attachments/assets/5228e75d-aec4-49a6-9ff8-73bd55226fc2) | ![Screenshot 2024-10-11 at 13 02 57](https://github.com/user-attachments/assets/f483909b-0366-4d23-8201-e2a0a2deddb3) |
| ![Screenshot 2024-10-11 at 13 08 11](https://github.com/user-attachments/assets/1f0ab231-0e5b-45fc-904e-b17c97e2be66) | ![Screenshot 2024-10-11 at 13 02 48](https://github.com/user-attachments/assets/d94e55c4-8501-4401-990e-21f21cd03d1d) |


https://github.com/user-attachments/assets/d7c33318-6ca3-4d39-95a8-c7f4ade621a2

